### PR TITLE
adds a go.mod file to make it possible to import packages

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module evm-from-scratch-go
+
+go 1.18


### PR DESCRIPTION
The go.mod file describes a go module. This makes it possible to use other go modules (packages) within the code base.