### PR TITLE
[typescript] add return type for evm

### DIFF
--- a/typescript/evm.ts
+++ b/typescript/evm.ts
@@ -12,7 +12,12 @@
  * - Use Jest Watch Mode to run tests when files change: `yarn test --watchAll`
  */
 
-export default function evm(code: Uint8Array) {
+type Result = {
+  success: boolean,
+  stack: number[]
+}
+
+export default function evm(code: Uint8Array): Result {
   let pc = 0;
   let stack = [];
 

--- a/typescript/evm.ts
+++ b/typescript/evm.ts
@@ -14,7 +14,7 @@
 
 type Result = {
   success: boolean,
-  stack: number[]
+  stack: bigint[]
 }
 
 export default function evm(code: Uint8Array): Result {


### PR DESCRIPTION
Small, quality of life improvement. Might save time for those who removed all function body and forgot that they need to return `{ stack }` instead of `stack`