### PR TITLE
Idiomatic Go harness using `go test`

### DIFF
--- a/go/evm.go
+++ b/go/evm.go
@@ -1,118 +1,30 @@
-/**
- * EVM From Scratch
- * Go template
- *
- * To work on EVM From Scratch in Go:
- *
- * - Install Golang: https://golang.org/doc/install
- * - Go to the `go` directory: `cd go`
- * - Edit `evm.go` (this file!), see TODO below
- * - Run `go run evm.go` to run the tests
- */
-
-package main
+// Package evm is an **incomplete** implementation of the Ethereum Virtual
+// Machine for the "EVM From Scratch" course:
+// https://github.com/w1nt3r-eth/evm-from-scratch
+//
+// To work on EVM From Scratch In Go:
+// - Install Golang: https://golang.org/doc/install
+// - Go to the `go` directory: `cd go`
+// - Edit `evm.go` (this file!), see TODO below
+// - Run `go test ./...` to run the tests
+package evm
 
 import (
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"log"
 	"math/big"
 )
 
-type code struct {
-	Bin string
-	Asm string
-}
-
-type expect struct {
-	Stack   []string
-	Success bool
-	Return  string
-}
-
-type TestCase struct {
-	Name   string
-	Hint   string
-	Code   code
-	Expect expect
-}
-
-func evm(code []byte) (bool, []big.Int) {
-	var stack []big.Int
+// Run runs the EVM code and returns the stack and a success indicator.
+func Run(code []byte) ([]*big.Int, bool) {
+	var stack []*big.Int
 	pc := 0
 
 	for pc < len(code) {
 		op := code[pc]
 		pc++
-		
-		if op == 0x00 {
-		}
+
 		// TODO: Implement the EVM here!
+		_ = op // delete this; it's only here to make the compiler think you're already using `op`
 	}
 
-
-	return true, stack
-}
-
-func main() {
-	content, err := ioutil.ReadFile("../evm.json")
-	if err != nil {
-		log.Fatal("Error when opening file: ", err)
-	}
-
-	var payload []TestCase
-	err = json.Unmarshal(content, &payload)
-	if err != nil {
-		log.Fatal("Error during json.Unmarshal(): ", err)
-	}
-
-	for index, test := range payload {
-		fmt.Printf("Test #%v of %v: %v\n", index + 1, len(payload), test.Name)
-
-		bin, err := hex.DecodeString(test.Code.Bin)
-		if err != nil {
-			log.Fatal("Error during hex.DecodeString(): ", err)
-		}
-
-		var expectedStack []big.Int
-		for _, s := range test.Expect.Stack {
-			i, ok := new(big.Int).SetString(s, 0)
-			if !ok {
-				log.Fatal("Error during big.Int.SetString(): ", err)
-			}
-			expectedStack = append(expectedStack, *i)
-		}
-
-		// Note: as the test cases get more complex, you'll need to modify this
-		// to pass down more arguments to the evm function and return more than
-		// just the stack.
-		success, stack := evm(bin)
-
-		match := len(stack) == len(expectedStack)
-		if match {
-			for i, s := range stack {
-				match = match && (s.Cmp(&expectedStack[i]) == 0)
-			}
-		}
-		match = match && (success == test.Expect.Success)
-
-		if !match {
-			fmt.Printf("Instructions: \n%v\n", test.Code.Asm)
-			fmt.Printf("Expected: success=%v, stack=%v\n", test.Expect.Success, toStrings(expectedStack))
-			fmt.Printf("Got:      success=%v, stack=%v\n\n", success, toStrings(stack))
-			fmt.Printf("Hint: %v\n\n", test.Hint)
-			fmt.Printf("Progress: %v/%v\n\n", index, len(payload))
-			log.Fatal("Stack mismatch")
-		}
-	}
-}
-
-func toStrings(stack []big.Int) []string {
-	var strings []string
-	for _, s := range stack {
-		strings = append(strings, s.String())
-	}
-	return strings
+	return stack, true
 }

--- a/go/evm.go
+++ b/go/evm.go
@@ -3,6 +3,7 @@
 // https://github.com/w1nt3r-eth/evm-from-scratch
 //
 // To work on EVM From Scratch In Go:
+//
 // - Install Golang: https://golang.org/doc/install
 // - Go to the `go` directory: `cd go`
 // - Edit `evm.go` (this file!), see TODO below

--- a/go/evm_test.go
+++ b/go/evm_test.go
@@ -1,0 +1,115 @@
+package evm
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type testCase struct {
+	Name string `json:"name"`
+	Hint string `json:"hint"`
+	Code code   `json:"code"`
+	Want want   `json:"expect"`
+}
+
+type code struct {
+	Bin string `json:"bin"`
+	Asm string `json:"asm"`
+}
+
+type want struct {
+	Stack   []hexBigInt `json:"stack"`
+	Success bool        `json:"success"`
+	Return  string      `json:"return"`
+}
+
+// A hexBigInt is a *big.Int that can be read from a JSON hex string.
+type hexBigInt struct {
+	*big.Int
+}
+
+// UnmarshalJSON unmarshals the buffer into i.Int; it expects the input to be
+// string-quoted.
+func (i *hexBigInt) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if i.Int == nil {
+		i.Int = new(big.Int)
+	}
+	return i.Int.UnmarshalJSON([]byte(s))
+}
+
+// StackInts returns the underlying *big.Int values of w.Stack, unwrapping them
+// from within the JSON-unmarshalling helper.
+func (w *want) StackInts() []*big.Int {
+	b := make([]*big.Int, len(w.Stack))
+	for i, s := range w.Stack {
+		b[i] = s.Int
+	}
+	return b
+}
+
+func TestEVM(t *testing.T) {
+	var tests []testCase
+	t.Run("setup", func(t *testing.T) {
+		const testSrc = "../evm.json"
+		buf, err := ioutil.ReadFile(testSrc)
+		if err != nil {
+			fatalAndBugReport(t, "ioutil.ReadFile(%q) error %v", testSrc, err)
+		}
+
+		if err := json.Unmarshal(buf, &tests); err != nil {
+			fatalAndBugReport(t, "json.Unmarshal([contents of %q], %T) error %v", testSrc, &tests, err)
+		}
+	})
+	if t.Failed() {
+		return
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			bin, err := hex.DecodeString(tt.Code.Bin)
+			if err != nil {
+				fatalAndBugReport(t, "hex.DecodeString(%q) error %v", tt.Code.Bin, err)
+			}
+
+			got, gotSuccess := Run(bin)
+			if gotSuccess != tt.Want.Success {
+				t.Errorf("Run(…) got success = %t; want %t", gotSuccess, tt.Want.Success)
+			}
+			if diff := cmp.Diff(tt.Want.StackInts(), got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Run(…) stack mismatch; diff (-want +got)\n%s", diff)
+			}
+
+			if t.Failed() {
+				t.Logf("EVM Instructions:\n%v", tt.Code.Asm)
+				if tt.Hint != "" {
+					t.Log("#####")
+					t.Logf("##### HINT: %s", tt.Hint)
+					t.Log("#####")
+				}
+			}
+		})
+		if t.Failed() {
+			t.Fatalf("Progress: %d/%d", i, len(tests))
+		}
+	}
+}
+
+// fatalAndBugReport calls t.Errorf(format, a...) and then t.Fatal() with a
+// message requesting that the student files a bug report. It's intended use is
+// as a replacement for t.Fatal() when the error is in the test setup, not in
+// the student's implementation.
+func fatalAndBugReport(t *testing.T, format string, a ...interface{}) {
+	t.Helper()
+	t.Errorf(format, a...)
+	t.Fatal("The error wasn't in your code. Please file a bug report at https://github.com/w1nt3r-eth/evm-from-scratch/issues/new")
+}

--- a/go/evm_test.go
+++ b/go/evm_test.go
@@ -3,8 +3,8 @@ package evm
 import (
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -61,13 +61,14 @@ func TestEVM(t *testing.T) {
 	var tests []testCase
 	t.Run("setup", func(t *testing.T) {
 		const testSrc = "../evm.json"
-		buf, err := ioutil.ReadFile(testSrc)
+		f, err := os.Open(testSrc)
 		if err != nil {
-			fatalAndBugReport(t, "ioutil.ReadFile(%q) error %v", testSrc, err)
+			fatalAndBugReport(t, "os.Open(%q) error %v", testSrc, err)
 		}
+		defer f.Close()
 
-		if err := json.Unmarshal(buf, &tests); err != nil {
-			fatalAndBugReport(t, "json.Unmarshal([contents of %q], %T) error %v", testSrc, &tests, err)
+		if err := json.NewDecoder(f).Decode(&tests); err != nil {
+			fatalAndBugReport(t, "json.NewDecoder(%q).Decode(%T) error %v", testSrc, &tests, err)
 		}
 	})
 	if t.Failed() {

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,5 @@
 module evm-from-scratch-go
 
 go 1.18
+
+require github.com/google/go-cmp v0.5.9

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
This now uses idiomatic Go constructs, particularly its in-built testing framework. Instead of `go run evm.go`, students now use `go test ./...` and receive familiar outputs.

You originally had the following comment, which doesn't play as nicely with the separation of implementation and tests. So as to not ruin it for anyone seeing this conversation, can you please DM me a couple of examples so I can figure out how to allow for this functionality?

```Go
// Note: as the test cases get more complex, you'll need to modify this
// to pass down more arguments to the evm function and return more than
// just the stack.
```